### PR TITLE
✨ Feat: job_posting 모델 작성

### DIFF
--- a/app/core/config.py
+++ b/app/core/config.py
@@ -22,7 +22,12 @@ TORTOISE_ORM = {
     "connections": {"default": POSTGRES_URL},
     "apps": {
         "models": {
-            "models": ["aerich.models"],
+            "models": [
+                "app.models.free_board_models",
+                "app.models.resume_models",
+                "app.models.job_posting_models",
+                "aerich.models",
+            ],
             "default_connection": "default",
         }
     },

--- a/app/models/job_posting_model.py
+++ b/app/models/job_posting_model.py
@@ -1,0 +1,56 @@
+from enum import Enum
+
+from tortoise import fields
+from tortoise.models import Model
+
+from app.utils.model import TimestampMixin
+
+
+class JobPosting(TimestampMixin, Model):
+    class EmploymentEnum(str, Enum):  # 공공, 일반 고용 형태 표시
+        Public = "공공"
+        General = "일반"
+
+    class StatusEnum(str, Enum):  # 공고 상태 표시
+        Open = "모집중"
+        Closing_soon = "마감 임박"
+        Closed = "모집 종료"
+        Blinded = "블라인드"
+
+    id = fields.IntField(pk=True)
+    user = fields.ForeignKeyField(
+        "user_model.User", related_name="job_postings", on_delete="CASCADE"
+    )
+    title = fields.CharField(max_length=100, unique=True)
+    location = fields.CharField(max_length=150)
+    employment_type = fields.CharEnumField(
+        EmploymentEnum, default=EmploymentEnum.General
+    )
+    position = fields.CharField(max_length=50)
+    history = fields.TextField(null=True)
+    recruitment_count = fields.IntField()
+    education = fields.CharField(max_length=20)
+    deadline = fields.CharField(max_length=20)
+    salary = fields.IntField()
+    summary = fields.TextField(null=True)
+    description = fields.TextField()
+    status = fields.CharEnumField(StatusEnum, default=StatusEnum.Open)
+    view_count = fields.IntField(default=0)
+    report = fields.IntField(default=0)
+
+    class Meta:
+        table = "job_postings"
+        ordering = ["-created_at"]
+
+
+class RejectPosting(TimestampMixin, Model):
+    id = fields.IntField(pk=True)
+    user = fields.ForeignKeyField(
+        "user_model.User", related_name="reject_postings", null=True
+    )
+    job_posting = fields.ForeignKeyField("JobPosting", related_name="reject_by_admins")
+    content = fields.TextField()
+
+    class Meta:
+        table = "reject_postings"
+        ordering = ["-created_at"]

--- a/app/models/job_posting_models.py
+++ b/app/models/job_posting_models.py
@@ -19,7 +19,7 @@ class JobPosting(TimestampMixin, Model):
 
     id = fields.IntField(pk=True)
     user = fields.ForeignKeyField(
-        "user_model.User", related_name="job_postings", on_delete="CASCADE"
+        "user_model.User", related_name="job_postings", on_delete=fields.CASCADE
     )
     title = fields.CharField(max_length=100, unique=True)
     location = fields.CharField(max_length=150)
@@ -74,7 +74,9 @@ class Applicants(Model):
     resume = fields.ForeignKeyField(
         "resume_models.Resume", related_name="applicants_resume"
     )
-    user = fields.ForeignKeyField("user_model.User", related_name="applied_user")
+    user = fields.ForeignKeyField(
+        "user_model.User", related_name="applied_user", on_delete=fields.CASCADE
+    )
     status = fields.CharEnumField(ApplicantEnum, default=ApplicantEnum.Applied)
 
     class Meta:

--- a/app/models/job_posting_models.py
+++ b/app/models/job_posting_models.py
@@ -31,7 +31,7 @@ class JobPosting(TimestampMixin, Model):
     recruitment_count = fields.IntField()
     education = fields.CharField(max_length=20)
     deadline = fields.CharField(max_length=20)
-    salary = fields.IntField()
+    salary = fields.IntField(default=0)
     summary = fields.TextField(null=True)
     description = fields.TextField()
     status = fields.CharEnumField(StatusEnum, default=StatusEnum.Open)
@@ -43,7 +43,7 @@ class JobPosting(TimestampMixin, Model):
         ordering = ["-created_at"]
 
 
-class RejectPosting(TimestampMixin, Model):
+class RejectPosting(Model):
     id = fields.IntField(pk=True)
     user = fields.ForeignKeyField(
         "user_model.User", related_name="reject_postings", null=True
@@ -53,4 +53,30 @@ class RejectPosting(TimestampMixin, Model):
 
     class Meta:
         table = "reject_postings"
+        ordering = ["-created_at"]
+
+
+class Region(Model):
+    id = fields.IntField(pk=True)
+    name = fields.CharField(max_length=50, unique=True)
+
+    class Meta:
+        table = "regions"
+
+
+class Applicants(Model):
+    class ApplicantEnum(str, Enum):
+        Applied = "지원 중"
+        Cancelled = "지원 취소"
+
+    id = fields.IntField(pk=True)
+    job_posting = fields.ForeignKeyField("JobPosting", related_name="applicants")
+    resume = fields.ForeignKeyField(
+        "resume_models.Resume", related_name="applicants_resume"
+    )
+    user = fields.ForeignKeyField("user_model.User", related_name="applied_user")
+    status = fields.CharEnumField(ApplicantEnum, default=ApplicantEnum.Applied)
+
+    class Meta:
+        table = "applicants"
         ordering = ["-created_at"]


### PR DESCRIPTION
job_posting 기본 모델 작성
    공공, 일반 / 공고 상태는 enum 처리 했습니다.
reject_posting 기본 모델 작성
    job_posting이 삭제되면 거절 이력도 삭제되어야 할까요...?
Region 모델 작성
Applicants 모델 작성
   지원중, 지원 취소에 대한 상태 정보는 enum 처리 했습니다.
   지원자가 삭제될 경우 해당 이력 또한 함께 삭제됩니다.